### PR TITLE
Fix thread shutdown on server stop

### DIFF
--- a/src/main/java/toni/packanalytics/PackAnalytics.java
+++ b/src/main/java/toni/packanalytics/PackAnalytics.java
@@ -66,6 +66,8 @@ public class PackAnalytics #if FABRIC implements ModInitializer #endif
     public static final String ID = "packanalytics";
     public static final Logger LOGGER = LogManager.getLogger(MODNAME);
 
+    private ScheduledExecutorService scheduler;
+
     public PackAnalytics(#if NEO IEventBus modEventBus, ModContainer modContainer #endif) {
         #if FORGE
         var context = FMLJavaModLoadingContext.get();
@@ -99,18 +101,37 @@ public class PackAnalytics #if FABRIC implements ModInitializer #endif
         #endif
 
         if (isDedicatedServer()) {
-            ServerLifecycleEvents.SERVER_STOPPING.register((mc) -> sendKeepAliveRequest(true));
+            ServerLifecycleEvents.SERVER_STOPPING.register((mc) -> {
+                sendKeepAliveRequest(true);
+                stopKeepAliveTask();
+            });
         }
         else {
-            ClientLifecycleEvents.CLIENT_STOPPING.register((mc) -> sendKeepAliveRequest(true));
+            ClientLifecycleEvents.CLIENT_STOPPING.register((mc) -> {
+                sendKeepAliveRequest(true);
+                stopKeepAliveTask();
+            });
         }
 
         startKeepAliveTask();
     }
 
     private void startKeepAliveTask() {
-        ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(1);
+        scheduler = Executors.newScheduledThreadPool(1);
         scheduler.scheduleAtFixedRate(() -> sendKeepAliveRequest(false), 1, AllConfigs.common().updateRate.get(), TimeUnit.MINUTES);
+    }
+
+    private void stopKeepAliveTask() {
+        if (scheduler != null && !scheduler.isShutdown()) {
+            scheduler.shutdown();
+            try {
+                if (!scheduler.awaitTermination(5, TimeUnit.SECONDS)) {
+                    scheduler.shutdownNow();
+                }
+            } catch (InterruptedException e) {
+                scheduler.shutdownNow();
+            }
+        }
     }
 
     private void sendKeepAliveRequest(boolean disconnect) {


### PR DESCRIPTION
This adds a way to stop the "keepAliveTask" when the server/clients shuts down.

This fixes #2

-- Copilot Generated Summary Below --

Add functionality to stop the keep-alive task on server shutdown.

* Add a class-level variable `scheduler` to store the `ScheduledExecutorService` instance.
* Modify the `startKeepAliveTask` method to store the `ScheduledExecutorService` instance in the `scheduler` variable.
* Add a new method `stopKeepAliveTask` to shut down the `ScheduledExecutorService`.
* Modify the `ServerLifecycleEvents.SERVER_STOPPING` and `ClientLifecycleEvents.CLIENT_STOPPING` events to call the `stopKeepAliveTask` method.

